### PR TITLE
Updated history_orders to new endpoint

### DIFF
--- a/pymexc/futures.py
+++ b/pymexc/futures.py
@@ -661,7 +661,7 @@ class HTTP(_FuturesHTTP):
         """
         return self.call(
             "GET",
-            "api/v1/private/order/history_orders",
+            "api/v1/private/order/list/history_orders",
             params=dict(
                 symbol=symbol,
                 states=states,


### PR DESCRIPTION
The history_orders() endpoint changed from
	`api/v1/private/order/history_orders`

to 
    `api/v1/private/order/list/history_orders`
   
See: https://mexcdevelop.github.io/apidocs/contract_v1_en/#get-all-of-the-user-39-s-historical-orders

Old endpoint returns a 511, forbidden.