### PR TITLE
Add interval parameter to deals_stream and WebSocket subscription methods

### DIFF
--- a/pymexc/_async/spot.py
+++ b/pymexc/_async/spot.py
@@ -2053,7 +2053,7 @@ class WebSocket(_SpotWebSocket):
     #
     # <=================================================================>
 
-    async def deals_stream(self, callback: Callable[..., None], symbol: Union[str, List[str]]):
+    async def deals_stream(self, callback: Callable[..., None], symbol: Union[str, List[str]], interval: str = None):
         """
         ### Trade Streams
         The Trade Streams push raw trade information; each trade has a unique buyer and seller.
@@ -2064,6 +2064,8 @@ class WebSocket(_SpotWebSocket):
         :type callback: Callable[..., None]
         :param symbol: the name of the contract
         :type symbol: Union[str,List[str]]
+        :param interval: the interval for the stream, default is None. Possible values '100ms' or '10s'
+        :type symbol: str
 
         :return: None
         """
@@ -2073,7 +2075,7 @@ class WebSocket(_SpotWebSocket):
             symbols = symbol  # list
         params = [dict(symbol=s) for s in symbols]
         topic = "public.aggre.deals"
-        await self._ws_subscribe(topic, callback, params)
+        await self._ws_subscribe(topic, callback, params, interval)
 
     async def kline_stream(self, callback: Callable[..., None], symbol: str, interval: int):
         """

--- a/pymexc/base_websocket.py
+++ b/pymexc/base_websocket.py
@@ -568,11 +568,15 @@ class _SpotWebSocketManager(_WebSocketManager):
 
         self.private_topics = ["account", "deals", "orders"]
 
-    def subscribe(self, topic: str, callback: Callable, params_list: list):
+    def subscribe(self, topic: str, callback: Callable, params_list: list, interval: str = None):
         subscription_args = {
             "method": "SUBSCRIPTION",
             "params": [
-                "@".join([f"spot@{topic}.v3.api" + (".pb" if self.proto else "")] + list(map(str, params.values())))
+                "@".join(
+                    [f"spot@{topic}.v3.api" + (".pb" if self.proto else "")] 
+                    + ([str(interval)] if interval else [])
+                    + list(map(str, params.values()))
+                )
                 for params in params_list
             ],
         }
@@ -654,8 +658,8 @@ class _SpotWebSocket(_SpotWebSocketManager):
 
         super().__init__(self.ws_name, **kwargs)
 
-    def _ws_subscribe(self, topic, callback, params: list = []):
+    def _ws_subscribe(self, topic, callback, params: list = [], interval: str = None):
         if not self.is_connected():
             self._connect(self.endpoint)
 
-        self.subscribe(topic, callback, params)
+        self.subscribe(topic, callback, params, interval)

--- a/pymexc/spot.py
+++ b/pymexc/spot.py
@@ -2039,6 +2039,7 @@ class WebSocket(_SpotWebSocket):
         self,
         callback: Callable[[dict | ProtoTyping.PublicDealsV3Api], None],
         symbol: Union[str, List[str]],
+        interval: str = None
     ):
         """
         ### Trade Streams
@@ -2050,6 +2051,8 @@ class WebSocket(_SpotWebSocket):
         :type callback: Callable[[dict | ProtoTyping.PublicDealsV3Api], None]
         :param symbol: the name of the contract
         :type symbol: Union[str,List[str]]
+        :param interval: the interval for the stream, default is None. Possible values '100ms' or '10s'
+        :type symbol: str
 
         :return: None
         """
@@ -2059,7 +2062,7 @@ class WebSocket(_SpotWebSocket):
             symbols = symbol  # list
         params = [dict(symbol=s) for s in symbols]
         topic = "public.aggre.deals"
-        self._ws_subscribe(topic, callback, params)
+        self._ws_subscribe(topic, callback, params, interval)
 
     def kline_stream(
         self,


### PR DESCRIPTION
Regarding documentation there are new parameter interval (100ms|10ms). https://mexcdevelop.github.io/apidocs/spot_v3_en/#websocket-market-streams